### PR TITLE
Remove o-ft-icons as dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "o-colors": "~3.3.0",
     "o-fonts": "^2.1.1",
-    "o-ft-icons": "^3.3.0 <5",
     "o-typography": "^3.1.0",
     "o-hoverable": "^3.0.0"
   }


### PR DESCRIPTION
Unsure why this was still included as a dependency, must have been left in by mistake. 

Would this be a patch change as it won't effect any other components' dependencies?
