### PR TITLE
Add new setting to Origami json for module grouping

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,7 @@
 {
     "description": "Card view of any kind of content",
     "origamiType": "module",
+    "origamiGroup": "component",
     "origamiVersion": 1,
     "support": "https://github.com/Financial-Times/o-card/issues",
     "supportStatus": "active",


### PR DESCRIPTION
Adding a new line to the `origami.json` to test the module grouping in the Registry update. 
