### PR TITLE
Update: o-typography version from ^3.1.0 to ^4.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "o-colors": "^3.3.0",
     "o-fonts": "^2.1.1",
-    "o-typography": "^4.3.0",
+    "o-typography": ">=3.1.0 <5",
     "o-hoverable": "^3.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "o-colors": "^3.3.0",
     "o-fonts": "^2.1.1",
-    "o-typography": "^3.1.0",
+    "o-typography": "^4.3.0",
     "o-hoverable": "^3.0.0"
   }
 }


### PR DESCRIPTION
@onishiweb @AlbertoElias @alicebartlett 

Only people whose names start with 'A' allowed here!

Am getting dependency clash in `n-section` build: https://circleci.com/gh/Financial-Times/n-section/107. When using `n-section` in `next-stream-page` `o-typography` resolves to v4.3.0 (and works fine locally), so I could simply add a resolution to `n-section` (as we are currently doing in `next-stream-page`), but feels better to address updating the version.
